### PR TITLE
update 'clusterPort' description

### DIFF
--- a/1.config_file/1.01_cluster.cnf.md
+++ b/1.config_file/1.01_cluster.cnf.md
@@ -32,7 +32,7 @@
 <td >clusterPort</td>
 <td >集群调度中心的端口</td>
 <td >无默认值</td>
-<td >clusterMode为zk时，此项可以空缺；clusterMode为zk时，配置ucore的端口号。</td>
+<td >clusterMode为zk时，此项可以空缺；clusterMode为ucore时，配置ucore的端口号。</td>
 </tr> 
 <tr>
 <td >rootPath</td>


### PR DESCRIPTION
update 'clusterPort' description：
from：
clusterMode为zk时，此项可以空缺；clusterMode为zk时，配置ucore的端口号。
to：
clusterMode为zk时，此项可以空缺；clusterMode为ucore时，配置ucore的端口号。